### PR TITLE
Move images to autopilotpattern repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Triton Jenkins
+# Jenkins autopilot pattern
 
 [![](https://badge.imagelayers.io/dekobon/triton-jenkins:latest.svg)](https://imagelayers.io/?images=dekobon/triton-jenkins:latest 'Get your own badge on imagelayers.io')
-[![DockerPulls](https://img.shields.io/docker/pulls/dekobon/triton-jenkins.svg)](https://registry.hub.docker.com/u/dekobon/triton-jenkins/)
-[![DockerStars](https://img.shields.io/docker/stars/dekobon/triton-jenkins.svg)](https://registry.hub.docker.com/u/dekobon/triton-jenkins/)
+[![DockerPulls](https://img.shields.io/docker/pulls/autopilotpattern/jenkins.svg)](https://registry.hub.docker.com/u/autopilotpattern/jenkins/)
+[![DockerStars](https://img.shields.io/docker/stars/autopilotpattern/jenkins.svg)](https://registry.hub.docker.com/u/autopilotpattern/jenkins/)
 
 This repo is an extension of the official [Jenkins](https://jenkins.io/) Docker image, designed to be self-operating according to the [autopilot pattern](http://autopilotpattern.io/). This application demonstrates support for building containers via [Joyent's Triton](https://www.joyent.com/) and for provisioning Jenkins slaves via Triton.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 jenkins:
-    image: 0x74696d/triton-jenkins:cb-integration
+    image: autopilotpattern/jenkins
     restart: always
     mem_limit: 8g
     ports:


### PR DESCRIPTION
@misterbisson and @dekobon this updates the repo to have container images moved under the autopilotpattern org.

The new images have been pushed to:
https://hub.docker.com/r/autopilotpattern/jenkins/
