### PR TITLE
Add Nginx front-end with Let's Encrypt SSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY etc/containerpilot.json /etc/containerpilot.json
 USER jenkins
 
 # Add Jenkins plugins
-RUN /usr/local/bin/install-plugins.sh git token-macro docker-plugin
+RUN /usr/local/bin/install-plugins.sh git github token-macro docker-plugin
 
 # Jenkins config and templates
 COPY usr/local/bin/first-run.sh /usr/local/bin/first-run.sh
@@ -64,7 +64,7 @@ COPY usr/local/bin/reload-jobs.sh /usr/local/bin/reload-jobs.sh
 COPY usr/share/jenkins/templates /usr/share/jenkins/templates
 
 EXPOSE 22
-EXPOSE 80
+EXPOSE 8000
 
 ENTRYPOINT []
 CMD ["/usr/local/bin/containerpilot", "/usr/local/bin/jenkins.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,29 @@ jenkins:
     restart: always
     mem_limit: 8g
     ports:
-      - 80
+      - 8000
       - 22
     labels:
       - triton.cns.services=jenkins
     env_file: _env
+
+# reverse proxy for protecting Jenkins w/ TLS
+nginx:
+    image: autopilotpattern/jenkins-nginx
+    restart: always
+    mem_limit: 256m
+    environment:
+      - BACKEND=jenkins
+      - CONSUL_AGENT=1
+      - ACME_ENV=
+      - ACME_DOMAIN=
+    env_file: _env
+    labels:
+      - triton.cns.services=jenkins-nginx
+    ports:
+      - 80
+      - 443
+      - 9090
 
 # Start with a single host which will bootstrap the cluster.
 # In production we'll want to use an HA cluster.
@@ -25,5 +43,5 @@ consul:
     dns:
        - 127.0.0.1
     labels:
-      - triton.cns.services=consul
+      - triton.cns.services=jenkins-consul
     command: -server -bootstrap -ui-dir /ui

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -10,7 +10,7 @@
   "services": [
     {
       "name": "jenkins",
-      "port": 80,
+      "port": 8000,
       "health": "/usr/local/bin/reload-jobs.sh check",
       "interfaces": [
         "eth0",

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -9,7 +9,7 @@ jenkins:
     links:
       - consul:consul
     ports:
-      - "8080:80"
+      - "8000:8000"
       - "2222:22"
 
 consul:
@@ -18,3 +18,19 @@ consul:
       service: consul
     ports:
       - "8500:8500"
+
+nginx:
+    extends:
+      file: docker-compose.yml
+      service: nginx
+    build: ./nginx
+    environment:
+      - CONSUL=consul
+      - ACME_ENV=
+      - ACME_DOMAIN=
+    links:
+      - consul:consul
+    ports:
+      - "8080:80"
+      - "4443:443"
+      - "9090:9090"

--- a/makefile
+++ b/makefile
@@ -1,0 +1,21 @@
+MAKEFLAGS += --warn-undefined-variables
+SHELL := /bin/bash
+.SHELLFLAGS := -eu -o pipefail
+.DEFAULT_GOAL := build
+
+TAG?=latest
+
+# run the Docker build
+build:
+	docker -f local-compose.yml build
+
+# push our image to the public registry
+ship:
+	docker tag jenkins_jenkins autopilotpattern/jenkins:${TAG}
+	docker tag jenkins_jenkins autopilotpattern/jenkins:latest
+	docker tag jenkins_nginx autopilotpattern/jenkins-nginx:${TAG}
+	docker tag jenkins_nginx autopilotpattern/jenkins-nginx:latest
+	docker push "autopilotpattern/jenkins:${TAG}"
+	docker push "autopilotpattern/jenkins-nginx:${TAG}"
+	docker push "autopilotpattern/jenkins:latest"
+	docker push "autopilotpattern/jenkins-nginx:latest"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,3 @@
+# Nginx container for securing access to Jenkins
+FROM autopilotpattern/nginx:latest
+COPY nginx.conf.ctmpl /etc/nginx/nginx.conf.ctmpl

--- a/nginx/nginx.conf.ctmpl
+++ b/nginx/nginx.conf.ctmpl
@@ -1,0 +1,138 @@
+# nginx configuration for reverse proxying local Jenkins server,
+# with Let's Encrypt protection.
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    map $status $isError {
+        ~^2 0;
+        default 1;
+    }
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    {{ $backend := env "BACKEND" }}
+    {{ $acme_domain := env "ACME_DOMAIN" }}
+    {{ $ssl_ready := env "SSL_READY" }}
+
+    {{ if service $backend }}
+    upstream jenkins {
+        {{ range service $backend }}
+        server {{.Address}}:{{.Port}};
+        {{end}}
+        least_conn;
+    }{{ end }}
+
+    server {
+        listen      80;
+        server_name _;
+
+        {{ if eq $ssl_ready "true" }}
+        location / {
+            return 301 https://$host$request_uri;
+        }
+        {{ else }}
+        location /.well-known/acme-challenge {
+            alias /var/www/acme/challenge;
+        }
+        location / {
+            # we don't want to return anything on this port until we've
+            # secured it via SSL
+            return 503;
+        }
+        {{ end }}
+
+        location /nginx-health {
+            stub_status;
+            allow 127.0.0.1;
+            deny all;
+            access_log /var/log/nginx/access.log  main if=$isError;
+        }
+    }
+
+    {{ if eq $ssl_ready "true" }}
+    server {
+        listen       443 ssl;
+        server_name  _;
+
+        location /nginx-health {
+            stub_status;
+            allow 127.0.0.1;
+            deny all;
+            access_log /var/log/nginx/access.log  main if=$isError;
+        }
+
+        location /.well-known/acme-challenge {
+            alias /var/www/acme/challenge;
+        }
+
+        ssl_certificate /var/www/ssl/fullchain.pem;
+        ssl_certificate_key /var/www/ssl/privkey.pem;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
+        ssl_session_timeout 1d;
+        ssl_session_cache shared:SSL:50m;
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        add_header Strict-Transport-Security max-age=15768000;
+
+        location / {
+            # reverse proxy recommendations from
+            # https://wiki.jenkins-ci.org/display/JENKINS/Running+Jenkins+behind+Nginx
+            # the major difference here is that we don't have the /userContent
+            # directory being served by Nginx because we aren't mounting the Jenkins
+            # container to this container
+
+            sendfile        off;
+
+            {{ if service $backend }}
+            proxy_pass      http://jenkins;
+            {{ end }}
+            proxy_redirect  default;
+
+            proxy_set_header    Host                $host;
+            proxy_set_header    X-Real-IP           $remote_addr;
+            proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+            proxy_set_header    X-Forwarded-Proto   https;
+            proxy_max_temp_file_size 0;
+
+            # max upload size
+            client_max_body_size        10m;
+            client_body_buffer_size     128k;
+
+            proxy_connect_timeout       90;
+            proxy_send_timeout          90;
+            proxy_read_timeout          90;
+            proxy_buffer_size           4k;
+            proxy_buffers               4 32k;
+            proxy_busy_buffers_size     64k;
+            proxy_temp_file_write_size  64k;
+
+        }
+
+    }
+    {{ end }}
+}

--- a/setup.sh
+++ b/setup.sh
@@ -104,7 +104,7 @@ check() {
     echo 'GITHUB_JOBS_SPEC=' >> _env
     echo >> _env
 
-    echo CONSUL=consul.svc.${TRITON_ACCOUNT}.${TRITON_DC}.cns.joyent.com >> _env
+    echo CONSUL=jenkins-consul.svc.${TRITON_ACCOUNT}.${TRITON_DC}.cns.joyent.com >> _env
     echo >> _env
 
     # variables we need for pointing Docker to Triton

--- a/usr/local/bin/jenkins.sh
+++ b/usr/local/bin/jenkins.sh
@@ -31,4 +31,4 @@ JAVA_OPTS="${JAVA_GC_FLAGS} ${MEMORY_SETTINGS} -Djava.net.preferIPv4Stack=true -
 
 authbind --deep java $JAVA_OPTS \
          -jar /usr/share/jenkins/jenkins.war \
-         --httpPort=80 $JENKINS_OPTS
+         --httpPort=8000 $JENKINS_OPTS


### PR DESCRIPTION
For https://github.com/autopilotpattern/jenkins/issues/6

@misterbisson @jasonpincin this puts Nginx in front of Jenkins, using the same Let's Encrypt setup that we have in autopilotpattern/nginx. The only thing we've changed from the Nginx config is adding the recommended reverse proxy for Jenkins.